### PR TITLE
chore: update @sanity/orderable-document-list to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@icons-pack/react-simple-icons": "9.4.0",
         "@portabletext/react": "3.0.11",
         "@sanity/image-url": "1.0.2",
-        "@sanity/orderable-document-list": "1.1.0",
+        "@sanity/orderable-document-list": "^1.2.1",
         "@sanity/vision": "3.32.0",
         "@tailwindcss/typography": "0.5.10",
         "@types/node": "20.11.25",
@@ -2453,9 +2453,9 @@
       }
     },
     "node_modules/@sanity/orderable-document-list": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@sanity/orderable-document-list/-/orderable-document-list-1.1.0.tgz",
-      "integrity": "sha512-8YUWEh7A0yZicawrXyhqvXZdTui6r4GZpqRYcxK4plhYr1rT9AmUdVlJ6sR/wOGt+62aUsi26PgRJEbgj/+Hww==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@sanity/orderable-document-list/-/orderable-document-list-1.2.1.tgz",
+      "integrity": "sha512-ZjbNuAI9TUbc+q3HbKjC1S43ywXwv5Ft1GihyBmIOeIl9wiTT9T8E543VuvIU0IcBGOGNUHag7IIs03TdcqWLQ==",
       "dependencies": {
         "@hello-pangea/dnd": "^16.2.0",
         "@sanity/icons": "^2.4.1",
@@ -2469,8 +2469,11 @@
         "node": ">=14"
       },
       "peerDependencies": {
+        "@sanity/ui": "^1.0 || ^2.0",
         "react": "^18",
-        "sanity": "^3"
+        "react-dom": "^18",
+        "sanity": "^3.0.0",
+        "styled-components": "^5.0 || ^6.0"
       }
     },
     "node_modules/@sanity/orderable-document-list/node_modules/@floating-ui/react-dom": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@icons-pack/react-simple-icons": "9.4.0",
     "@portabletext/react": "3.0.11",
     "@sanity/image-url": "1.0.2",
-    "@sanity/orderable-document-list": "1.1.0",
+    "@sanity/orderable-document-list": "1.2.1",
     "@sanity/vision": "3.32.0",
     "@tailwindcss/typography": "0.5.10",
     "@types/node": "20.11.25",

--- a/sanity/config.ts
+++ b/sanity/config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'sanity'
-import { deskTool } from 'sanity/desk'
+import { structureTool } from 'sanity/structure'
 import { visionTool } from '@sanity/vision'
 import { orderableDocumentListDeskItem } from '@sanity/orderable-document-list'
 import { Paintbrush, Info } from 'lucide-react'
@@ -14,7 +14,7 @@ export default defineConfig({
   projectId,
   dataset,
   plugins: [
-    deskTool({
+    structureTool({
       structure: (S, context) =>
         S.list()
           .title('Content')


### PR DESCRIPTION
- update @sanity/orderable-document-list to 1.2.1
- switch from deprecated `deskTool` to `structureTool`